### PR TITLE
RHMAP-6233 - Update mongodb driver (>= 2.1.0) + test node 4.x support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,7 +84,7 @@ module.exports = function(grunt) {
           stdout: true,
           stderr: true
         },
-        command: 'env NODE_PATH=. ./node_modules/.bin/mocha -A -u exports --recursive test/server.js test/accept/'
+        command: 'env NODE_PATH=. ./node_modules/.bin/mocha -A -u exports --recursive application.js test/accept/'
       },
       coverage_unit: {
         options: {

--- a/application.js
+++ b/application.js
@@ -29,6 +29,7 @@ app.use(mbaasExpress.errorHandler());
 
 var port = process.env.FH_PORT || process.env.OPENSHIFT_NODEJS_PORT || 8001;
 var host = process.env.OPENSHIFT_NODEJS_IP || '0.0.0.0';
+
 app.listen(port, host, function() {
   console.log("App started at: " + new Date() + " on port: " + port); 
 });

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "fh-service-mongodb-cloud",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {
     "express": "4.0.0",
     "fh-mbaas-api": "5.12.0",
     "request": "2.34.0",
     "body-parser": "~1.0.2",
     "cors": "~2.2.0",
-    "mongodb": "1.3.12"
+    "mongodb": ">=2.1.0"
   },
   "devDependencies": {
     "grunt-concurrent": "latest",


### PR DESCRIPTION
# Motivation

Update the mongodb dependency version to >=2.1.0.

Tested against node 0.10.43/4.4.5 and mongodb 2.4/2.6/3.3.6 

# Changes

* Updated package.json dependency;
* Modified the server path in unit test to use "application.js" file.

[RHMAP-6233](https://issues.jboss.org/browse/RHMAP-6233)